### PR TITLE
Remove duplicate struct name ht_item

### DIFF
--- a/02-hash-table/README.md
+++ b/02-hash-table/README.md
@@ -4,7 +4,7 @@ Our key-value pairs (items) will each be stored in a `struct`:
 
 ```c
 // hash_table.h
-typedef struct ht_item {
+typedef struct {
     char* key;
     char* value;
 } ht_item;


### PR DESCRIPTION
I haven't written C in about a decade and I have compiled any of this yet, but I think there was an extra `ht_item` there.