### PR TITLE
Fix Error in Hashing Algorithm

### DIFF
--- a/03-hashing/README.md
+++ b/03-hashing/README.md
@@ -65,8 +65,8 @@ static int ht_hash(const char* s, const int a, const int m) {
     const int len_s = strlen(s);
     for (int i = 0; i < len_s; i++) {
         hash += (long)pow(a, len_s - (i+1)) * s[i];
-        hash = hash % m;
     }
+    hash = hash % m;
     return (int)hash;
 }
 ```


### PR DESCRIPTION
Previously the bucket modulo was being performed every iteration of the
loop, instead of at the very end as described in the pseudocode.