### PR TITLE
fix ht_del_hash_table function after point deleted item to HT_DELETED_ITEM

### DIFF
--- a/05-methods/README.md
+++ b/05-methods/README.md
@@ -154,5 +154,19 @@ void ht_insert(ht_hash_table* ht, const char* key, const char* value) {
 }
 ```
 
+We also need to modify the `ht_del_hash_table` to skip the deleted item.
+```c
+void ht_del_hash_table(ht_hash_table* ht) {
+    for (int i = 0; i < ht->size; i++) {
+        ht_item* item = ht->items[i];
+        if (item != NULL && item != &HT_DELETED_ITEM) {
+            ht_del_item(item);
+        }
+    }
+    free(ht->items);
+    free(ht);
+}
+```
+
 Next section: [Resizing tables](/06-resizing)
 [Table of contents](https://github.com/jamesroutley/write-a-hash-table#contents)


### PR DESCRIPTION
Hi, i follow your tutorial to write the code,  and found `ht_del_hash_table` function  need to skip the deleted item, or there would be an error.