### PR TITLE
Update README.md part 02-hash-table

### DIFF
--- a/02-hash-table/README.md
+++ b/02-hash-table/README.md
@@ -92,7 +92,7 @@ one. Although it doesn't do much at this point, we can still try it out.
 
 ```c
 // main.c
-#include "hash_table.h"
+#include "hash_table.c"
 
 int main() {
     ht_hash_table* ht = ht_new();


### PR DESCRIPTION
I think the include should change to "hash_table.c" instead of "hash_table.h". 
One might get an error trying to run the `main.c` with the wrong include.