### PR TITLE
[MAJOR BUG FIX] - Fixed bad free() calls, fixed decrement bug for ht_delete

### DIFF
--- a/05-methods/README.md
+++ b/05-methods/README.md
@@ -84,13 +84,14 @@ void ht_delete(ht_hash_table* ht, const char* key) {
             if (strcmp(item->key, key) == 0) {
                 ht_del_item(item);
                 ht->items[index] = &HT_DELETED_ITEM;
+                ht->count--;
+                return;
             }
         }
         index = ht_get_hash(key, ht->size, i);
         item = ht->items[index];
         i++;
     } 
-    ht->count--;
 }
 ```
 After deleting, we decrement the hash table's `count` attribute.

--- a/05-methods/README.md
+++ b/05-methods/README.md
@@ -96,11 +96,13 @@ void ht_delete(ht_hash_table* ht, const char* key) {
 ```
 After deleting, we decrement the hash table's `count` attribute.
 
-We also need to modify `ht_insert` and `ht_search` functions to take account of
+We also need to modify `ht_insert`, `ht_search`, and `ht_del_hash_table` functions to take account of
 deleted nodes.
 
 When searching, we ignore and 'jump over' deleted nodes. When inserting, if we
 hit a deleted node, we can insert the new node into the deleted slot.
+
+When deleting the hash table, we need to make sure to not call free() on the HT_DELETED_ITEM pointers.
 
 ```c
 // hash_table.c
@@ -124,6 +126,17 @@ char* ht_search(ht_hash_table* ht, const char* key) {
         // ...
     }
     // ...
+}
+
+void ht_del_hash_table(ht_hash_table* ht) {
+    for (int i = 0; i < ht->size; i++) {
+        ht_item* item = ht->items[i];
+        if (item != NULL && item != &HT_DELETED_ITEM) {
+            ht_del_item(item);
+        }
+    }
+    free(ht->items);
+    free(ht);
 }
 ```
 


### PR DESCRIPTION
Before, in ht_del_hash_table, free() would be called on pointers to HT_DELETED_ITEM, resulting in an error.

Also before, calling ht_delete with key that's not in the hash table would result in ht_count being decremented anyway.
Added an early return for when the item is marked as no further checks need to be made.